### PR TITLE
Field value translation in cart

### DIFF
--- a/plugins/stockablecustomfields/stockablecustomfields.php
+++ b/plugins/stockablecustomfields/stockablecustomfields.php
@@ -1015,7 +1015,7 @@ class plgVmCustomStockablecustomfields extends vmCustomPlugin
 				if ($newProductCustom->field_type!='E') {
 					$html  .= '<span class="product-field-type-S">';
 					$html  .= '<span class="product-field-label">'.JText::_($newProductCustom->custom_title).': </span>';
-					$html  .= '<span class="product-field-value">'.$newProductCustom->customfield_value.'</span>';
+					$html  .= '<span class="product-field-value">'.JText::_($newProductCustom->customfield_value).'</span>';
 					$html  .= '</span>';
 					$html.='<br/>';
 				}


### PR DESCRIPTION
Custom field value was not translated in shopping cart view. This patch solves this issue.

Test instructions:
1/ Create product variant with string custom field type
2/ Use for example NONSENSE as variant field value
3/ Go to language override of Joomla and add new constant for frontend - key should be NONSENSE, value for example "makes sense"
4/ Go to frontend - in product details you sholud see translated string (makes sense)
5/ Add variant to cart - in the cart you should see non translated string (NONSENSE)
6/ Apply this patch
7/ See the cart again